### PR TITLE
Add the mqtt example service

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,0 +1,9 @@
+FROM alpine:latest
+
+RUN apk update \
+    && apk add --no-cache bash mosquitto \
+    && rm -fr /tmp/*
+
+COPY mqtt.sh /
+WORKDIR /
+CMD ["./mqtt.sh"]

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,0 +1,9 @@
+FROM alpine:latest
+
+RUN apk update \
+    && apk add --no-cache bash mosquitto \
+    && rm -fr /tmp/*
+
+COPY mqtt.sh /
+WORKDIR /
+CMD ["./mqtt.sh"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,9 @@
+FROM alpine:latest
+
+RUN apk update \
+    && apk add --no-cache bash mosquitto \
+    && rm -fr /tmp/*
+
+COPY mqtt.sh /
+WORKDIR /
+CMD ["./mqtt.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,75 @@
+# Make targets for building the mqtt service for the visual_inferencing edge service
+
+# This imports the variables from horizon/hzn.json. You can ignore these lines, but do not remove them
+-include horizon/.hzn.json.tmp.mk
+
+# Default ARCH to the architecture of this machines (as horizon/golang describes it)
+export ARCH ?= $(shell hzn architecture)
+
+# Configurable parameters passed to serviceTest.sh in "test" target
+export MATCH:='Starting mqtt broker...'
+export TIME_OUT:=60
+
+# Build the docker image for the current architecture
+build:
+	docker build -t $(DOCKER_IMAGE_BASE)_$(ARCH):$(SERVICE_VERSION) -f ./Dockerfile.$(ARCH) .
+
+# Build the docker image for 3 architectures
+build-all-arches:
+	ARCH=amd64 $(MAKE) build
+	ARCH=arm $(MAKE) build
+	ARCH=arm64 $(MAKE) build
+
+# Target for travis to test new PRs
+test-all-arches:
+	ARCH=amd64 $(MAKE) test
+	ARCH=arm $(MAKE) test
+	ARCH=arm64 $(MAKE) test
+
+# Run and verify the service
+test: build
+	hzn dev service start -S
+	@echo 'Testing service...'
+	../../../tools/serviceTest.sh $(SERVICE_NAME) $(MATCH) $(TIME_OUT) && \
+		{ hzn dev service stop; \
+		echo "*** Service test succeeded! ***"; } || \
+		{ hzn dev service stop; \
+		echo "*** Service test failed! ***"; \
+		false ;}
+
+# Target for travis to publish service and pattern after PR is merged  
+publish: 
+	ARCH=amd64 $(MAKE) publish-service
+	ARCH=arm $(MAKE) publish-service
+	ARCH=arm64 $(MAKE) publish-service
+
+# Publish the service to the Horizon Exchange for the current architecture
+publish-service:
+	hzn exchange service publish -O -f horizon/service.definition.json
+
+# Build, run and verify, if test succeeds then publish (for the current architecture)
+#build-test-publish: build test publish-service
+
+# target for script - overwrite and pull insitead of push docker image
+publish-service-overwrite:
+	hzn exchange service publish -O -P -f horizon/service.definition.json
+
+# new target for icp exchange to run on startup to publish only
+publish-only:
+	ARCH=amd64 $(MAKE) publish-service-overwrite
+	ARCH=arm $(MAKE) publish-service-overwrite
+	ARCH=arm64 $(MAKE) publish-service-overwrite
+
+clean:
+	-docker rmi $(DOCKER_IMAGE_BASE)_$(ARCH):$(SERVICE_VERSION) 2> /dev/null || :
+
+clean-all-archs:
+	ARCH=amd64 $(MAKE) clean
+	ARCH=arm $(MAKE) clean
+	ARCH=arm64 $(MAKE) clean
+
+# This imports the variables from horizon/hzn.cfg. You can ignore these lines, but do not remove them.
+horizon/.hzn.json.tmp.mk: horizon/hzn.json
+	@ hzn util configconv -f $< | sed 's/=/?=/' > $@
+
+.PHONY: build build-all-arches test publish-service build-test-publish publish-all-arches clean clean-all-archs

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# mqtt
+# Horizon MQTT Broker Service
+
+The MQTT Broker service provides an mqtt broker and publisher for inter-container commmunication. 
+
+### **API:** 
+---
+
+#### Publishing:
+
+```
+mosquitto_pub [-d] [-h host] [-p port] {-f file | -m message} [-t topic]
+```
+
+#### Parameters:
+
+| Name | Description |
+| ---- | ---------------- |
+| -h | host name | 
+| -d | put the broker into the background after starting |
+| -p | publish on the specified port |
+| -f | send the contents of a file as the message | 
+| -m | message payload to send | 
+| -t | mqtt topic to publish to |
+
+#### Subscribing:
+
+```
+mosquitto_sub [-h host] [-p port] [-t topic]
+```
+
+#### Parameters:
+
+| Name | Description |
+| ---- | ---------------- |
+| -h | host name |  
+| -p | subscribe on the specified port |
+| -t | mqtt topic to subscribe to |

--- a/horizon/hzn.json
+++ b/horizon/hzn.json
@@ -1,0 +1,9 @@
+{
+    "HZN_ORG_ID": "IBM",
+    "MetadataVars": {
+        "DOCKER_IMAGE_BASE": "openhorizon/ibm.mqtt",
+        "SERVICE_NAME": "ibm.mqtt",
+        "SERVICE_VERSION": "1.0.0"
+    }
+}
+

--- a/horizon/service.definition.json
+++ b/horizon/service.definition.json
@@ -1,0 +1,19 @@
+{
+  "org": "$HZN_ORG_ID",
+  "label": "$SERVICE_NAME for $ARCH",
+  "url": "$SERVICE_NAME",
+  "version": "$SERVICE_VERSION",
+  "arch": "$ARCH",
+  "public": true,
+  "sharable": "singleton",
+  "requiredServices": [],
+  "userInput": [],
+  "deployment": {
+    "services": {
+      "$SERVICE_NAME": {
+        "image": "${DOCKER_IMAGE_BASE}_$ARCH:$SERVICE_VERSION"
+      }
+    }
+  }
+}
+

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -1,0 +1,13 @@
+# Place your local configuration in /etc/mosquitto/conf.d/
+# 
+# A full description of the configuration file is at
+# /usr/share/doc/mosquitto/examples/mosquitto.conf.example
+
+pid_file /var/run/mosquitto.pid
+
+persistence true
+persistence_location /var/lib/mosquitto/
+
+log_dest file /var/log/mosquitto/mosquitto.log
+
+include_dir /etc/mosquitto/conf.d

--- a/mqtt.sh
+++ b/mqtt.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Starting mqtt broker..."
+mosquitto -c /etc/mosquitto/mosquitto.conf


### PR DESCRIPTION
Partially addresses this [open-horizon/examples issue](https://github.com/open-horizon/examples/issues/392).

This version of mqtt is from @t-fine's [achatina branch](https://github.com/t-fine/examples/tree/achatina/edge/services/mqtt), which adds Dockerfiles for other architectures.

Signed-off-by: Clement Ng <clementdng@gmail.com>