### PR TITLE
Use the provided mosquitto.conf file to run mqtt broker

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -5,5 +5,10 @@ RUN apk update \
     && rm -fr /tmp/*
 
 COPY mqtt.sh /
+COPY mosquitto.conf /
 WORKDIR /
+RUN mkdir -p /etc/mosquitto/conf.d \
+    && chmod -R o+w /etc/mosquitto/conf.d/
+RUN mkdir -p /var/log/mosquitto \
+    && chmod -R o+w /var/log/mosquitto/
 CMD ["./mqtt.sh"]

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -5,5 +5,10 @@ RUN apk update \
     && rm -fr /tmp/*
 
 COPY mqtt.sh /
+COPY mosquitto.conf /
 WORKDIR /
+RUN mkdir -p /etc/mosquitto/conf.d \
+    && chmod -R o+w /etc/mosquitto/conf.d/
+RUN mkdir -p /var/log/mosquitto \
+    && chmod -R o+w /var/log/mosquitto/
 CMD ["./mqtt.sh"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -5,5 +5,10 @@ RUN apk update \
     && rm -fr /tmp/*
 
 COPY mqtt.sh /
+COPY mosquitto.conf /
 WORKDIR /
+RUN mkdir -p /etc/mosquitto/conf.d \
+    && chmod -R o+w /etc/mosquitto/conf.d/
+RUN mkdir -p /var/log/mosquitto \
+    && chmod -R o+w /var/log/mosquitto/
 CMD ["./mqtt.sh"]

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -1,7 +1,4 @@
 # Place your local configuration in /etc/mosquitto/conf.d/
-# 
-# A full description of the configuration file is at
-# /usr/share/doc/mosquitto/examples/mosquitto.conf.example
 
 pid_file /var/run/mosquitto.pid
 

--- a/mqtt.sh
+++ b/mqtt.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo "Starting mqtt broker..."
-mosquitto -c /etc/mosquitto/mosquitto.conf
+mosquitto -c /mosquitto.conf


### PR DESCRIPTION
To use the existing `mosquitto.conf` in the repo, I had to set up and `chmod` certain directories in the docker container. I also removed one of the comments that was no longer true regarding the description of the configuration file.

Tested by building and running the docker container, installing the `mosquitto-clients` package, and then testing that `mosquitto_sub -h localhost -t test` and `mosquitto_pub -h localhost -t test -m "hello world"` function as expected.
 
Signed-off-by: Clement Ng <clementdng@gmail.com>