### PR TITLE
Add password-based authentication

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -7,6 +7,7 @@ RUN apk update \
 COPY mqtt.sh /
 COPY mosquitto.conf /
 WORKDIR /
+RUN touch /etc/mosquitto/passwd
 RUN mkdir -p /etc/mosquitto/conf.d \
     && chmod -R o+w /etc/mosquitto/conf.d/
 RUN mkdir -p /var/log/mosquitto \

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -7,6 +7,7 @@ RUN apk update \
 COPY mqtt.sh /
 COPY mosquitto.conf /
 WORKDIR /
+RUN touch /etc/mosquitto/passwd
 RUN mkdir -p /etc/mosquitto/conf.d \
     && chmod -R o+w /etc/mosquitto/conf.d/
 RUN mkdir -p /var/log/mosquitto \

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -7,6 +7,7 @@ RUN apk update \
 COPY mqtt.sh /
 COPY mosquitto.conf /
 WORKDIR /
+RUN touch /etc/mosquitto/passwd
 RUN mkdir -p /etc/mosquitto/conf.d \
     && chmod -R o+w /etc/mosquitto/conf.d/
 RUN mkdir -p /var/log/mosquitto \

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ export ARCH ?= $(shell hzn architecture)
 # Configurable parameters passed to serviceTest.sh in "test" target
 export MATCH:='Starting mqtt broker...'
 export TIME_OUT:=60
+DOCKER_NAME := $(ARCH)_mqtt
 
 # Build the docker image for the current architecture
 build:
@@ -19,6 +20,17 @@ build-all-arches:
 	ARCH=amd64 $(MAKE) build
 	ARCH=arm $(MAKE) build
 	ARCH=arm64 $(MAKE) build
+
+# Run the docker image for the current architecture
+run:
+	-docker rm -f $(DOCKER_NAME) 2> /dev/null || :
+	docker run -e MQTT_USERNAME -e MQTT_PASSWORD -d --name $(DOCKER_NAME) $(DOCKER_IMAGE_BASE)_$(ARCH):$(SERVICE_VERSION)
+
+# Run the docker image for 3 architectures
+run-all-arches:
+	ARCH=amd64 $(MAKE) run
+	ARCH=arm $(MAKE) run
+	ARCH=arm64 $(MAKE) run
 
 # Target for travis to publish service and pattern after PR is merged  
 publish: 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,19 @@ The MQTT Broker service provides an mqtt broker and publisher for inter-containe
 
 ### **API:** 
 ---
+#### Authentication:
+
+This service is configured to use password-based authentication. By default, the username is set to `mqtt` and the password is `password`. To customize these attributes, please set these environment variables.
+
+```
+export MQTT_USERNAME=<desired-username>
+export MQTT_PASSWORD=<desired-password>
+```
 
 #### Publishing:
 
 ```
-mosquitto_pub [-d] [-h host] [-p port] {-f file | -m message} [-t topic]
+mosquitto_pub [-d] [-h host] [-p port] {-f file | -m message} [-t topic] [-u username] [-P password]
 ```
 
 #### Parameters:
@@ -26,11 +34,13 @@ mosquitto_pub [-d] [-h host] [-p port] {-f file | -m message} [-t topic]
 | -f | send the contents of a file as the message | 
 | -m | message payload to send | 
 | -t | mqtt topic to publish to |
+| -u | mqtt username |
+| -P | mqtt password |
 
 #### Subscribing:
 
 ```
-mosquitto_sub [-h host] [-p port] [-t topic]
+mosquitto_sub [-h host] [-p port] [-t topic] [-u username] [-P password]
 ```
 
 #### Parameters:
@@ -40,6 +50,8 @@ mosquitto_sub [-h host] [-p port] [-t topic]
 | -h | host name |  
 | -p | subscribe on the specified port |
 | -t | mqtt topic to subscribe to |
+| -u | mqtt username |
+| -P | mqtt password |
 
 [mqtt-version-shield]: https://img.shields.io/badge/version-1.0.0-blue.svg
 [mqtt-amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg

--- a/horizon/service.definition.json
+++ b/horizon/service.definition.json
@@ -7,7 +7,20 @@
   "public": true,
   "sharable": "singleton",
   "requiredServices": [],
-  "userInput": [],
+  "userInput": [
+    {
+      "name": "MQTT_USERNAME",
+      "label": "The mqtt username",
+      "type": "string",
+      "defaultValue": "mqtt"
+    },
+    {
+      "name": "MQTT_PASSWORD",
+      "label": "The password for the provided mqtt user",
+      "type": "string",
+      "defaultValue": "password"
+    }
+  ],
   "deployment": {
     "services": {
       "$SERVICE_NAME": {

--- a/horizon/userinput.json
+++ b/horizon/userinput.json
@@ -1,0 +1,12 @@
+{
+    "services": [
+        {
+            "org": "$HZN_ORG_ID",
+            "url": "$SERVICE_NAME",
+            "variables": {
+                "MQTT_USERNAME": "$MQTT_USERNAME",
+                "MQTT_PASSWORD": "$MQTT_PASSWORD"
+            }
+        }
+    ]
+}

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -7,4 +7,7 @@ persistence_location /var/lib/mosquitto/
 
 log_dest file /var/log/mosquitto/mosquitto.log
 
+allow_anonymous false
+password_file /etc/mosquitto/passwd
+
 include_dir /etc/mosquitto/conf.d

--- a/mqtt.sh
+++ b/mqtt.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+echo "Setting up mqtt passwords..."
+mosquitto_passwd -b /etc/mosquitto/passwd $MQTT_USERNAME $MQTT_PASSWORD
+
 echo "Starting mqtt broker..."
 mosquitto -c /mosquitto.conf


### PR DESCRIPTION
Addresses part of #2 

This commit adds password-based authentication. The default username is `mqtt` and default password is `password`, but users can change the values by setting the environment variables `MQTT_USERNAME` AND `MQTT_PASSWORD`. Note that this uses `mosquitto_passwd -b` (batch mode) to set these up, so the password is visible in the command line and command history.

Ran `make build` and then both `make run` (a new `make` target) and `hzn dev service start -S`. In both, tested that password-based authentication test worked from https://www.digitalocean.com/community/tutorials/how-to-install-and-secure-the-mosquitto-mqtt-messaging-broker-on-debian-10.

Signed-off-by: Clement Ng <clementdng@gmail.com>